### PR TITLE
Support multiple types of project managers and add `uv` functionality

### DIFF
--- a/module/functions/_generatePythonCoverageXml.ps1
+++ b/module/functions/_generatePythonCoverageXml.ps1
@@ -13,10 +13,10 @@
 function _generatePythonCoverageXml
 {
     [CmdletBinding()]
-    param ()
+    param ($ToolPath)
 
     exec {
-        & $script:PoetryPath run `
+        & $ToolPath run `
             coverage `
             xml `
             -o $PythonCoverageReportPath

--- a/module/functions/_runBehave.ps1
+++ b/module/functions/_runBehave.ps1
@@ -13,7 +13,7 @@
 function _runBehave
 {
     [CmdletBinding()]
-    param ()
+    param ($ToolPath)
 
     $testReportsPath = (Join-Path $here "behave-test-reports-temp")
     if (Test-Path $testReportsPath) {
@@ -24,7 +24,7 @@ function _runBehave
 
     try {
         exec {
-            & $script:PoetryPath run `
+            & $ToolPath run `
                 coverage `
                 run `
                 --append `
@@ -38,7 +38,7 @@ function _runBehave
     }
     finally {
         exec {
-            & $script:PoetryPath run junitparser merge --glob $testReportsPath/*.xml $BehaveResultsPath
+            & $ToolPath run junitparser merge --glob $testReportsPath/*.xml $BehaveResultsPath
         }
     }
 }

--- a/module/functions/_runPyTest.ps1
+++ b/module/functions/_runPyTest.ps1
@@ -13,10 +13,10 @@
 function _runPyTest
 {
     [CmdletBinding()]
-    param ()
+    param ($ToolPath, $RunParams = @())
 
     exec {
-        & $script:PoetryPath run --no-interaction -v `
+        & $ToolPath run $RunParams `
             pytest `
             --cov=$PythonSourceDirectory `
             --cov-report= `

--- a/module/functions/_runPyTest.ps1
+++ b/module/functions/_runPyTest.ps1
@@ -16,7 +16,7 @@ function _runPyTest
     param ($ToolPath, $RunParams = @())
 
     exec {
-        & $ToolPath run $RunParams `
+        & $ToolPath run @RunParams `
             pytest `
             --cov=$PythonSourceDirectory `
             --cov-report= `

--- a/module/functions/_runUvPublish.ps1
+++ b/module/functions/_runUvPublish.ps1
@@ -1,0 +1,24 @@
+# <copyright file="_runUvPublish.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+    An internal wrapper function that runs 'uv publish' and can be mocked in tests.
+.DESCRIPTION
+    An internal wrapper function that runs 'uv publish' and can be mocked in tests.
+.EXAMPLE
+    _runUvPublish
+#>
+
+function _runUvPublish
+{
+    [CmdletBinding()]
+    param ()
+    
+    & $script:UvPath `
+        publish `
+        -u $script:PythonPublishUsername `
+        -p $env:PYTHON_PACKAGE_REPOSITORY_KEY `
+        ---publish-url $script:PythonPackageRepositoryUrl
+}

--- a/module/functions/_runUvPublish.ps1
+++ b/module/functions/_runUvPublish.ps1
@@ -18,6 +18,7 @@ function _runUvPublish
     
     & $script:UvPath `
         publish `
+        @uvGlobalArgs `
         -u $script:PythonPublishUsername `
         -p $env:PYTHON_PACKAGE_REPOSITORY_KEY `
         ---publish-url $script:PythonPackageRepositoryUrl

--- a/module/functions/_runUvPublish.ps1
+++ b/module/functions/_runUvPublish.ps1
@@ -16,10 +16,10 @@ function _runUvPublish
     [CmdletBinding()]
     param ()
     
-    & $script:UvPath `
+    & $script:PythonUvPath `
         publish `
         @uvGlobalArgs `
         -u $script:PythonPublishUsername `
         -p $env:PYTHON_PACKAGE_REPOSITORY_KEY `
-        ---publish-url $script:PythonPackageRepositoryUrl
+        --publish-url $script:PythonPackageRepositoryUrl --verbose
 }

--- a/module/tasks/build.properties.ps1
+++ b/module/tasks/build.properties.ps1
@@ -33,7 +33,7 @@ $PythonPoetryVersion = property POETRY_VERSION ""
 $PoetryPath = property ZF_BUILD_PYTHON_POETRY_PATH ((Get-Command poetry -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path) ?? "")
 
 # Synopsis: The version of uv to use for the build. Default is the latest version.
-$PythonUvVersion = property ZF_BUILD_PYTHON_UV_VERSION "uv"
+$PythonUvVersion = property ZF_BUILD_PYTHON_UV_VERSION ""
 
 # Synopsis: The arguments passed to the Python flake8 linter, override to customise its behaviour. Default is "-v".
 $PythonFlake8Args = "-v"

--- a/module/tasks/build.properties.ps1
+++ b/module/tasks/build.properties.ps1
@@ -8,8 +8,17 @@ $SkipInstallPythonPoetry = [Convert]::ToBoolean((property ZF_BUILD_PYTHON_SKIP_I
 # Synopsis: When true, the build will not run 'poetry install' to initialise the virtual environment.
 $SkipInitialisePythonPoetry = [Convert]::ToBoolean((property ZF_BUILD_PYTHON_SKIP_INIT_POETRY $false))
 
+# Synopsis: When true, the build will assume that Python uv is already installed and available in the PATH.
+$SkipInstallPythonUv = [Convert]::ToBoolean((property ZF_BUILD_PYTHON_SKIP_INSTALL_UV $false))
+
+# Synopsis: When true, the build will not run 'uv sync' to initialise the virtual environment.
+$SkipInitialisePythonUv = [Convert]::ToBoolean((property ZF_BUILD_PYTHON_SKIP_INIT_UV $false))
+
 # Synopsis: When true, the build will not run the flake8 linter.
 $SkipRunFlake8 = [Convert]::ToBoolean((property ZF_BUILD_PYTHON_SKIP_RUN_FLAKE8 $false))
+
+# Synopsis: The project/package manager to use for the Python project. Supported values are "poetry" or "uv". Default is "poetry".
+$PythonProjectManager = property ZF_BUILD_PYTHON_PROJECT_MANAGER "poetry"
 
 # Synopsis: The root path of the Python project. For example, this is used to locate the 'pyproject.toml' file.
 $PythonProjectDir = property ZF_BUILD_PYTHON_PROJECT_PATH ""
@@ -22,6 +31,9 @@ $PythonPoetryVersion = property POETRY_VERSION ""
 
 # Synopsis: The path to where Python Poetry is installed. By default the build will attempt to locate it via the PATH environment variable.
 $PoetryPath = property ZF_BUILD_PYTHON_POETRY_PATH ((Get-Command poetry -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path) ?? "")
+
+# Synopsis: The version of uv to use for the build. Default is the latest version.
+$PythonUvVersion = property ZF_BUILD_PYTHON_UV_VERSION "uv"
 
 # Synopsis: The arguments passed to the Python flake8 linter, override to customise its behaviour. Default is "-v".
 $PythonFlake8Args = "-v"

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -101,7 +101,12 @@ task InstallPythonUv -If { !$SkipInstallPythonUv } {
         # If the uv binary is not found, install it
         if (!(Test-Path (Join-Path $uvBinPath "uv"))) {
             Write-Build White "Installing uv $env:UV_VERSION"
-            Invoke-RestMethod https://astral.sh/uv/$env:UV_VERSION/install.ps1 | Invoke-Expression
+            if ($IsWindows) {
+                Invoke-RestMethod https://astral.sh/uv/$env:UV_VERSION/install.ps1 | Invoke-Expression
+            }
+            else {
+                Invoke-RestMethod https://astral.sh/uv/$env:UV_VERSION/install.sh | bash
+            }
 
             # Ensure the uv tool is available to the rest of the build process
             $script:UvPath = Join-Path $uvBinPath "uv"

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -100,12 +100,12 @@ task InstallPythonUv -If { !$SkipInstallPythonUv } {
     if (!$existingUv) {
         # If the uv binary is not found, install it
         if (!(Test-Path (Join-Path $uvBinPath "uv"))) {
-            Write-Build White "Installing uv $env:UV_VERSION"
+            Write-Build White "Installing uv $PythonUvVersion"
             if ($IsWindows) {
-                Invoke-RestMethod https://astral.sh/uv/$env:UV_VERSION/install.ps1 | Invoke-Expression
+                Invoke-RestMethod https://astral.sh/uv/$PythonUvVersion/install.ps1 | Invoke-Expression
             }
             else {
-                Invoke-RestMethod https://astral.sh/uv/$env:UV_VERSION/install.sh | bash
+                Invoke-RestMethod https://astral.sh/uv/$PythonUvVersion/install.sh | bash
             }
 
             # Ensure the uv tool is available to the rest of the build process

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -128,4 +128,4 @@ task RunFlake8 -If { $PythonProjectDir -ne "" -and !$SkipRunFlake8 } InitialiseP
 }
 
 # Synopsis: Runs the Python build process.
-task BuildPython -If { $PythonProjectDir -ne "" } -After BuildCore InitialisePythonPoetry,InstallPythonUv,RunFlake8
+task BuildPython -If { $PythonProjectDir -ne "" } -After BuildCore InitialisePythonPoetry,InitialisePythonUv,RunFlake8

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -70,7 +70,7 @@ task UpdatePoetryLockfile -If { !$IsRunningOnBuildServer } InstallPythonPoetry,{
 }
 
 # Synopsis: Initialise the Python Poetry virtual environment.
-task InitialisePythonPoetry -If { $PythonProjectManager -eq "poetry" -and $PythonProjectDir -ne "" -and !$SkipInitialisePythonPoetry } InstallPythonPoetry,UpdatePoetryLockfile,{
+task InitialisePythonPoetry -If { !$SkipInitialisePythonPoetry } InstallPythonPoetry,UpdatePoetryLockfile,{
     if (!(Test-Path (Join-Path $PythonProjectDir "pyproject.toml"))) {
         throw "pyproject.toml not found in $PythonProjectDir"
     }
@@ -111,7 +111,7 @@ task UpdateUvLockfile -If { !$IsRunningOnBuildServer } InstallPythonUv,{
     exec { & $script:PythonUvPath lock }
 }
 
-task InitialisePythonUv -If { $PythonProjectManager -eq "uv" -and $PythonProjectDir -ne "" -and !$SkipInitialisePythonUv } InstallPythonUv,UpdateUvLockfile,{
+task InitialisePythonUv -If { !$SkipInitialisePythonUv } InstallPythonUv,UpdateUvLockfile,{
     if (!(Test-Path (Join-Path $PythonProjectDir "pyproject.toml"))) {
         throw "pyproject.toml not found in $PythonProjectDir"
     }
@@ -128,4 +128,7 @@ task RunFlake8 -If { $PythonProjectDir -ne "" -and !$SkipRunFlake8 } InitialiseP
 }
 
 # Synopsis: Runs the Python build process.
-task BuildPython -If { $PythonProjectDir -ne "" } -After BuildCore InitialisePythonPoetry,InitialisePythonUv,RunFlake8
+task BuildPython -If { $PythonProjectDir -ne "" } -After BuildCore BuildPythonPoetry,BuildPythonUv,RunFlake8
+
+task BuildPythonPoetry -If { $PythonProjectManager -eq "poetry" -and $PythonProjectDir -ne "" } -After BuildCore InitialisePythonPoetry
+task BuildPythonUv -If { $PythonProjectManager -eq "uv" -and $PythonProjectDir -ne "" } -After BuildCore InitialisePythonUv

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -70,7 +70,7 @@ task UpdatePoetryLockfile -If { !$IsRunningOnBuildServer } InstallPythonPoetry,{
 }
 
 # Synopsis: Initialise the Python Poetry virtual environment.
-task InitialisePythonPoetry -If { $PythonProjectManager -eq "poetry" -and!$SkipInitialisePythonPoetry } InstallPythonPoetry,UpdatePoetryLockfile,{
+task InitialisePythonPoetry -If { $PythonProjectManager -eq "poetry" -and !$SkipInitialisePythonPoetry } InstallPythonPoetry,UpdatePoetryLockfile,{
     if (!(Test-Path (Join-Path $PythonProjectDir "pyproject.toml"))) {
         throw "pyproject.toml not found in $PythonProjectDir"
     }

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -109,7 +109,7 @@ task InstallPythonUv -If { !$SkipInstallPythonUv } {
             }
 
             # Ensure the uv tool is available to the rest of the build process
-            $script:UvPath = Join-Path $uvBinPath "uv"
+            $script:PythonUvPath = Join-Path $uvBinPath "uv"
             Write-Build Green "uv now available: $UvPath"
             if ($uvBinPath -notin ($env:PATH -split [System.IO.Path]::PathSeparator)) {
                 Write-Build White "Adding uv to PATH: $uvBinPath"

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -89,7 +89,7 @@ task InitialisePythonPoetry -If { !$SkipInitialisePythonPoetry } InstallPythonPo
     exec { & $script:PoetryPath install @poetryGlobalArgs --with dev,test }
 }
 
-task InstallPythonUv -If { $SkipInstallPythonPoetry } {
+task InstallPythonUv -If { !$SkipInstallPythonUv } {
 
     $existingUv = Get-Command uv -ErrorAction SilentlyContinue
     if (!$existingUv) {

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -98,6 +98,10 @@ task InstallPythonUv -If { $SkipInstallPythonPoetry } {
             Write-Build White "Installing uv $env:UV_VERSION"
             Invoke-RestMethod https://astral.sh/uv/$env:UV_VERSION/install.ps1 | Invoke-Expression
         }
+
+        $uv = Get-Command uv -ErrorAction SilentlyContinue
+        $script:PythonUvPath = $uv.Path
+        Write-Build Green "uv now available: $PythonUvPath"
     }
     else {
         $script:PythonUvPath = $existingUv.Path

--- a/module/tasks/package.tasks.ps1
+++ b/module/tasks/package.tasks.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot/package.properties.ps1
 
 # Synopsis: Build Python packages using Poetry. This task will build the packages and place them in the 'dist' directory.
-task BuildPythonPackages -If { $PythonProjectDir -ne "" -and !$SkipBuildPythonPackages } -After PackageCore Version,EnsurePackagesDir,InitialisePythonPoetry,{
+task BuildPythonPackages -If { $PythonProjectDir -ne "" -and !$SkipBuildPythonPackages } -After PackageCore Version,EnsurePackagesDir,InitialisePythonPoetry,InitialisePythonUv,{
     if (Test-Path (Join-Path $PythonProjectDir "dist")) {
         Remove-Item (Join-Path $PythonProjectDir "dist") -Recurse -Force
     }
@@ -25,7 +25,7 @@ task BuildPythonPackages -If { $PythonProjectDir -ne "" -and !$SkipBuildPythonPa
 
     Write-Build White "Building Python packages with version: $pythonPackageVersion"
     if ($PythonProjectManager -eq "uv") {
-        exec { & $script:UvPath version $pythonPackageVersion }
+        exec { & $script:PythonUvPath version @uvGlobalArgs $pythonPackageVersion }
     }
     elseif ($PythonProjectManager -eq "poetry") {
         exec { & $script:PoetryPath version @poetryGlobalArgs $pythonPackageVersion }
@@ -36,7 +36,7 @@ task BuildPythonPackages -If { $PythonProjectDir -ne "" -and !$SkipBuildPythonPa
 
     # Build the package(s)
     if ($PythonProjectManager -eq "uv") {
-        exec { & $script:UvPath build --wheel --out-dir $PackagesDir }
+        exec { & $script:PythonUvPath build --wheel --out-dir $PackagesDir }
     }
     elseif ($PythonProjectManager -eq "poetry") {
         # For the moment we live with the fact that Poetry's output path is not configurable
@@ -50,7 +50,7 @@ task BuildPythonPackages -If { $PythonProjectDir -ne "" -and !$SkipBuildPythonPa
 }
 
 # Synopsis: Publishes the built Python packages to the specified repository.
-task PublishPythonPackages -If { $PythonProjectDir -ne "" -and !$SkipPublishPythonPackages } -After PublishCore  InitialisePythonPoetry,{
+task PublishPythonPackages -If { $PythonProjectDir -ne "" -and !$SkipPublishPythonPackages } -After PublishCore  InitialisePythonPoetry,InitialisePythonUv,{
 
     # Copy the Python packages from the standard packaging output folder to where Poetry/uv expects to find them
     $distPath = Join-Path $PythonProjectDir "dist"

--- a/module/tasks/test.tasks.ps1
+++ b/module/tasks/test.tasks.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot/test.properties.ps1
 
 # Synopsis: Runs any PyTest and/or Behave tests in the Python source code.
-task RunPythonTests -If { $PythonProjectDir -ne "" || ($SkipRunPyTest && $SkipRunBehave) } -After TestCore InitialisePythonPoetry,{
+task RunPythonTests -If { $PythonProjectDir -ne "" || ($SkipRunPyTest && $SkipRunBehave) } -After TestCore InitialisePythonPoetry,InitialisePythonUv,{
 
     Write-Build White "Removing previous Python coverage results"
     # Explicitly change directory as 'coverage erase' does not run when Poetry has the '--directory' argument
@@ -27,7 +27,9 @@ task RunPythonTests -If { $PythonProjectDir -ne "" || ($SkipRunPyTest && $SkipRu
                 Write-Build White "Running PyTest..."
 
                 if ($PythonProjectManager -eq "uv") {
-                    $runParams = @()
+                    $runParams = @(
+                        "--verbose"
+                    )
                 }
                 elseif ($PythonProjectManager -eq "poetry") {
                     $runParams = @(

--- a/module/tasks/test.tasks.ps1
+++ b/module/tasks/test.tasks.ps1
@@ -10,14 +10,32 @@ task RunPythonTests -If { $PythonProjectDir -ne "" || ($SkipRunPyTest && $SkipRu
     Write-Build White "Removing previous Python coverage results"
     # Explicitly change directory as 'coverage erase' does not run when Poetry has the '--directory' argument
     Set-Location $PythonProjectDir
-    exec { & $script:PoetryPath run coverage erase }
+
+    if ($PythonProjectManager -eq "uv") {
+        $toolPath = $script:PythonUvPath
+    }
+    elseif ($PythonProjectManager -eq "poetry") {
+        $toolPath = $script:PoetryPath
+    }
+
+    exec { & $toolPath run coverage erase }
 
     $pythonTestErrors = @()
     try {
         try {
             if (!$SkipRunPyTest) {
                 Write-Build White "Running PyTest..."
-                _runPyTest
+
+                if ($PythonProjectManager -eq "uv") {
+                    $runParams = @()
+                }
+                elseif ($PythonProjectManager -eq "poetry") {
+                    $runParams = @(
+                        "--no-interaction"
+                        "-v"
+                    )
+                }
+                _runPyTest $toolPath $runParams
             }
         }
         catch {
@@ -28,7 +46,7 @@ task RunPythonTests -If { $PythonProjectDir -ne "" || ($SkipRunPyTest && $SkipRu
         try {
             if (!$SkipRunBehave) {
                 Write-Build White "Running Behave..."
-                _runBehave
+                _runBehave $toolPath
             }
         }
         catch {
@@ -38,7 +56,7 @@ task RunPythonTests -If { $PythonProjectDir -ne "" || ($SkipRunPyTest && $SkipRu
     }
     finally {
         Write-Build White "Generating Python coverage report"
-        _generatePythonCoverageXml
+        _generatePythonCoverageXml $toolPath
 
         if ($pythonTestErrors) {
             $pythonTestsErrorMsg = "{0}{1}" -f [Environment]::NewLine, ($pythonTestErrors -join [Environment]::NewLine) 


### PR DESCRIPTION
The type of Python project manager can be changed by setting the `$PythonProjectManager` build variable to `"uv"` or `"python"`