### PR TITLE
Enable more control over which dependency groups get installed

### DIFF
--- a/module/tasks/build.properties.ps1
+++ b/module/tasks/build.properties.ps1
@@ -37,3 +37,15 @@ $PythonUvVersion = property ZF_BUILD_PYTHON_UV_VERSION ""
 
 # Synopsis: The arguments passed to the Python flake8 linter, override to customise its behaviour. Default is "-v".
 $PythonFlake8Args = "-v"
+
+# Synopsis: Array of the default arguments passed to 'poetry install', override to customise its behaviour. Default is "--all-groups".
+$PoetryInstallArgs = @("--all-groups")
+
+# Synopsis: Array of the arguments passed to 'poetry install' when running on CI/CD servers, override to customise its behaviour. Default is @("--without", "dev").
+$PoetryInstallCicdArgs = @("--without", "dev")
+
+# Synopsis: Array of the default arguments passed to 'uv sync', override to customise its behaviour. Default is "--all-groups".
+$UvSyncArgs = @("--all-groups")
+
+# Synopsis: Array of the arguments passed to 'uv sync' when running on CI/CD servers, override to customise its behaviour. Default is @("--no-dev").
+$UvSyncCicdArgs = @("--no-dev")

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -86,7 +86,14 @@ task InitialisePythonPoetry -If { $PythonProjectManager -eq "poetry" -and !$Skip
     )
     Write-Build White "poetryGlobalArgs: $poetryGlobalArgs"
 
-    exec { & $script:PoetryPath install @poetryGlobalArgs --with dev,test }
+    if ($IsRunningOnBuildServer ) {
+        Write-Build Green "Installing dependencies for CI environment ('$($PoetryInstallCicdArgs -join " ")')"
+        exec { & $script:PoetryPath install @poetryGlobalArgs @PoetryInstallCicdArgs }
+    }
+    else {
+        Write-Build Green "Installing dependencies for local environment ('$($PoetryInstallArgs -join " ")')"
+        exec { & $script:PoetryPath install @poetryGlobalArgs @PoetryInstallArgs }
+    }
 }
 
 task InstallPythonUv -If { !$SkipInstallPythonUv } {
@@ -145,7 +152,14 @@ task InitialisePythonUv -If { $PythonProjectManager -eq "uv" -and !$SkipInitiali
     )
     Write-Build White "uvGlobalArgs: $uvGlobalArgs"
 
-    exec { & $script:PythonUvPath sync @uvGlobalArgs }
+    if ($IsRunningOnBuildServer ) {
+        Write-Build Green "Installing dependencies for CI environment ('$($UvSyncCicdArgs -join " ")')"
+        exec { & $script:PythonUvPath sync @uvGlobalArgs @UvSyncCicdArgs }
+    }
+    else {
+        Write-Build Green "Installing dependencies for local environment ('$($UvSyncArgs -join " ")')"
+        exec { & $script:PythonUvPath sync @uvGlobalArgs @UvSyncArgs }
+    }
 }
 
 # Synopsis: Run the flake8 linter on the Python source code.


### PR DESCRIPTION
Also optimise the typical CI/CD scenario by omitting `dev` dependencies.

When using `poetry` the following new properties are available:
```
$PoetryInstallArgs = @("--all-groups")
$PoetryInstallCicdArgs = @("--without", "dev")
```

Whilst `uv` uses these properties:
```
$UvSyncArgs = @("--all-groups")
$UvSyncCicdArgs = @("--no-dev")
```