### PR TITLE
Fix bugs for older versions of Poetry

### DIFF
--- a/module/tasks/build.properties.ps1
+++ b/module/tasks/build.properties.ps1
@@ -39,7 +39,7 @@ $PythonUvVersion = property ZF_BUILD_PYTHON_UV_VERSION ""
 $PythonFlake8Args = "-v"
 
 # Synopsis: Array of the default arguments passed to 'poetry install', override to customise its behaviour. Default is "--all-groups".
-$PoetryInstallArgs = @("--all-groups")
+$PoetryInstallArgs = @()
 
 # Synopsis: Array of the arguments passed to 'poetry install' when running on CI/CD servers, override to customise its behaviour. Default is @("--without", "dev").
 $PoetryInstallCicdArgs = @("--without", "dev")

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -86,13 +86,22 @@ task InitialisePythonPoetry -If { $PythonProjectManager -eq "poetry" -and !$Skip
     )
     Write-Build White "poetryGlobalArgs: $poetryGlobalArgs"
 
+    # Handle the addition of the preferred 'sync' command in later versions of Poetry
+    if ($poetryVersion.Major -lt 2) {
+        $poetryInstallCmd = "install"
+    }
+    else {
+        $poetryInstallCmd = "sync"
+    }
+    Write-Build White "poetryInstallCommand: $poetryInstallCmd"
+
     if ($IsRunningOnBuildServer ) {
         Write-Build Green "Installing dependencies for CI environment ('$($PoetryInstallCicdArgs -join " ")')"
-        exec { & $script:PoetryPath install @poetryGlobalArgs @PoetryInstallCicdArgs }
+        exec { & $script:PoetryPath $poetryInstallCmd @poetryGlobalArgs @PoetryInstallCicdArgs }
     }
     else {
         Write-Build Green "Installing dependencies for local environment ('$($PoetryInstallArgs -join " ")')"
-        exec { & $script:PoetryPath install @poetryGlobalArgs @PoetryInstallArgs }
+        exec { & $script:PoetryPath $poetryInstallCmd @poetryGlobalArgs @PoetryInstallArgs }
     }
 }
 

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -20,7 +20,7 @@ task InstallPythonPoetry -If { !$SkipInstallPythonPoetry } EnsurePython,{
         # The install script will honour this environment variable. If not explicitly set, we set it to:
         #  - On build servers we install within the working directory to ensure it's part of the build agent caching
         #  - Otherwise, we install to the user profile directory in a cross-platform way
-        $env:POETRY_HOME ??= $IsRunningOnBuildServer ? (Join-Path $here ".poetry") : (Join-Path ($IsWindows ? $env:USERPROFILE : $env:HOME) ".poetry")
+        $env:POETRY_HOME ??= $IsRunningOnCICDServer ? (Join-Path $here ".poetry") : (Join-Path ($IsWindows ? $env:USERPROFILE : $env:HOME) ".poetry")
         $env:POETRY_VERSION = $PythonPoetryVersion
         $poetryBinPath = Join-Path $env:POETRY_HOME "bin"
 
@@ -50,7 +50,7 @@ task InstallPythonPoetry -If { !$SkipInstallPythonPoetry } EnsurePython,{
 }
 
 # Synopsis: Updates the Poetry lockfile without updating any packages. This is useful for local development scenarios to ensure that the lockfile is in sync with the pyproject.toml file.
-task UpdatePoetryLockfile -If { !$IsRunningOnBuildServer } InstallPythonPoetry,{
+task UpdatePoetryLockfile -If { !$IsRunningOnCICDServer } InstallPythonPoetry,{
     Write-Build White "Ensuring poetry.lock is up-to-date - no packages will be updated"
 
     # Extract the Poetry version from the output of the --version command
@@ -95,7 +95,7 @@ task InitialisePythonPoetry -If { $PythonProjectManager -eq "poetry" -and !$Skip
     }
     Write-Build White "poetryInstallCommand: $poetryInstallCmd"
 
-    if ($IsRunningOnBuildServer ) {
+    if ($IsRunningOnCICDServer ) {
         Write-Build Green "Installing dependencies for CI environment ('$($PoetryInstallCicdArgs -join " ")')"
         exec { & $script:PoetryPath $poetryInstallCmd @poetryGlobalArgs @PoetryInstallCicdArgs }
     }
@@ -109,7 +109,7 @@ task InstallPythonUv -If { !$SkipInstallPythonUv } {
     # The install script will honour this environment variable. If not explicitly set, we set it to:
     #  - On build servers we install within the working directory to ensure it's part of the build agent caching
     #  - Otherwise, we install to the user profile directory in a cross-platform way
-    $env:UV_INSTALL_DIR ??= $IsRunningOnBuildServer ? (Join-Path $here ".uv") : (Join-Path ($IsWindows ? $env:USERPROFILE : $env:HOME) ".uv")
+    $env:UV_INSTALL_DIR ??= $IsRunningOnCICDServer ? (Join-Path $here ".uv") : (Join-Path ($IsWindows ? $env:USERPROFILE : $env:HOME) ".uv")
     $uvBinPath = $env:UV_INSTALL_DIR
 
     $existingUv = Get-Command uv -ErrorAction SilentlyContinue
@@ -144,7 +144,7 @@ task InstallPythonUv -If { !$SkipInstallPythonUv } {
     }
 }
 
-task UpdateUvLockfile -If { !$IsRunningOnBuildServer } InstallPythonUv,{
+task UpdateUvLockfile -If { !$IsRunningOnCICDServer } InstallPythonUv,{
     Write-Build White "Ensuring uv.lock is up-to-date - no packages will be updated"
 
     exec { & $script:PythonUvPath lock --project=$PythonProjectDir }
@@ -161,7 +161,7 @@ task InitialisePythonUv -If { $PythonProjectManager -eq "uv" -and !$SkipInitiali
     )
     Write-Build White "uvGlobalArgs: $uvGlobalArgs"
 
-    if ($IsRunningOnBuildServer ) {
+    if ($IsRunningOnCICDServer ) {
         Write-Build Green "Installing dependencies for CI environment ('$($UvSyncCicdArgs -join " ")')"
         exec { & $script:PythonUvPath sync @uvGlobalArgs @UvSyncCicdArgs }
     }

--- a/module/tasks/build.tasks.ps1
+++ b/module/tasks/build.tasks.ps1
@@ -61,11 +61,11 @@ task UpdatePoetryLockfile -If { !$IsRunningOnBuildServer } InstallPythonPoetry,{
     Set-Location $PythonProjectDir
     if ($poetryVersion.Major -lt 2) {
         # Poetry versions less v2.0.0 default to updating package versions
-        & $script:PoetryPath update --no-update
+        & $script:PoetryPath lock --no-update
     }
     else {
         # Poetry v2 and later will not update package versions by default
-        & $script:PoetryPath update
+        & $script:PoetryPath lock
     }
 }
 


### PR DESCRIPTION
- Use of the `--all-groups` argument with `poetry install` is not valid for older versions
- For later versions of Poetry, `poetry sync` is preferred over `poetry install` - [ref](https://python-poetry.org/docs/cli/#install)
- The method used to update `poetry.lock` was unnecessarily invasive
- Fixes bug with detecting when running on CI/CD server for `poetry` & `uv` scenarios